### PR TITLE
Fix CNF formula to comply with DIMACS

### DIFF
--- a/popravljenSAT/h_sudoku2.txt
+++ b/popravljenSAT/h_sudoku2.txt
@@ -1,5 +1,5 @@
 c hudobni_sudoku2.txt
-p cnf 1560 36050 0
+p cnf 1560 36050
 51 67 0
 51 99 0
 51 144 0


### PR DESCRIPTION
The second line of your example DIMACS file contains an extra zero, which I'm removing so all programs can read the file.
